### PR TITLE
Add chat-peek tool and refactor AI logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ A simple console tool that:
 python3 transcribe_audio.py path/to/audio.mp3 [-o path/to/output.txt]
 ```
 
+### `chat-peek`
+
+A CLI tool for inspecting exported chat logs from GitHub Copilot Chat.
+
+**Usage:**
+
+```bash
+chat-peek session.json
+chat-peek -a session.json
+chat-peek -h session.json > out.html
+```
+
+`chat-peek` works with the base dependencies of this project. For colored
+terminal output or HTML rendering, install the optional packages `rich` and
+`markdown`.
+
 ## Installation
 
 This project uses `uv` for dependency management with a `pyproject.toml`.

--- a/src/ai.py
+++ b/src/ai.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Utility functions for interacting with AI services."""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+
+load_dotenv()
+
+
+def get_openai_api_key() -> Optional[str]:
+    """Return the OpenAI API key from environment variables or .env."""
+    return os.getenv("OPENAI_API_KEY")
+
+
+def get_openai_client(api_key: Optional[str] = None) -> OpenAI:
+    """Return an ``OpenAI`` client instance using the given or configured key."""
+    if api_key is None:
+        api_key = get_openai_api_key()
+    if not api_key:
+        raise ValueError(
+            "OPENAI_API_KEY not set in .env or environment variables"
+        )
+    return OpenAI(api_key=api_key)
+
+
+def transcribe_audio(
+    input_path: str,
+    *,
+    language: Optional[str] = None,
+    prompt: Optional[str] = None,
+) -> str:
+    """Return the transcript of ``input_path`` using ``gpt-4o-transcribe``."""
+    client = get_openai_client()
+    with open(input_path, "rb") as audio_file:
+        kwargs = {"model": "gpt-4o-transcribe", "file": audio_file}
+        if language:
+            kwargs["language"] = language
+        if prompt:
+            kwargs["prompt"] = prompt
+        response = client.audio.transcriptions.create(**kwargs)
+    return response.text if hasattr(response, "text") else str(response)
+
+
+def summarize_text(_text: str) -> str:
+    """Placeholder for future AI-powered summarization."""
+    raise NotImplementedError("Summary feature not implemented yet.")
+
+
+__all__ = [
+    "get_openai_api_key",
+    "get_openai_client",
+    "transcribe_audio",
+    "summarize_text",
+]

--- a/src/chat-peek.py
+++ b/src/chat-peek.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Inspect GitHub Copilot Chat log exports."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Iterable, List, Tuple
+
+try:
+    from rich.console import Console
+    from rich.markdown import Markdown
+except Exception:  # pragma: no cover - optional dependency
+    Console = None
+    Markdown = None
+
+
+try:
+    import markdown as md_lib
+except Exception:  # pragma: no cover - optional dependency
+    md_lib = None
+
+
+from ai import summarize_text
+
+
+Message = Tuple[str, str]
+
+
+def load_chat(path: str) -> List[Message]:
+    """Return conversation as a list of ``(speaker, text)`` tuples."""
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    conversation: List[Message] = []
+    for req in data.get("requests", []):
+        user_text = req.get("message", {}).get("text", "")
+        conversation.append(("User", user_text))
+
+        response_parts: List[str] = []
+        for part in req.get("response", []):
+            if isinstance(part, str):
+                response_parts.append(part)
+            elif isinstance(part, dict):
+                for key in ("value", "text", "response"):
+                    if key in part:
+                        response_parts.append(part[key])
+                        break
+        ai_text = "".join(response_parts)
+        conversation.append(("AI", ai_text))
+    return conversation
+
+
+def format_markdown(conv: Iterable[Message]) -> str:
+    """Return the conversation formatted as Markdown."""
+    lines: List[str] = []
+    for speaker, text in conv:
+        lines.append(f"**{speaker}:**\n")
+        lines.append(text.strip())
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
+def format_ascii(conv: Iterable[Message]) -> None:
+    """Render the conversation to the terminal with colors using Rich."""
+    if Console and Markdown:
+        console = Console()
+        for speaker, text in conv:
+            console.print(f"[bold]{speaker}:[/bold]")
+            console.print(Markdown(text))
+    else:
+        print(format_markdown(conv))
+
+
+def format_html(conv: Iterable[Message]) -> str:
+    """Return the conversation as HTML."""
+    md_text = format_markdown(conv)
+    if md_lib is None:
+        return "<pre>" + md_text + "</pre>"
+    return md_lib.markdown(md_text)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Render a GitHub Copilot chat log",
+        add_help=False,
+    )
+    parser.add_argument("json_file", help="Path to chat export JSON")
+    parser.add_argument(
+        "-a",
+        "--ascii",
+        action="store_true",
+        help="Render conversation with colored ASCII",
+    )
+    parser.add_argument(
+        "-h", "--html", dest="html", action="store_true", help="Output as HTML"
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Summarize conversation using AI (future feature)",
+    )
+    parser.add_argument("--help", action="help", help="Show this help message")
+
+    args = parser.parse_args()
+
+    try:
+        conversation = load_chat(args.json_file)
+    except FileNotFoundError:
+        print(f"Error: cannot read file '{args.json_file}'", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as exc:
+        print(f"Error: invalid JSON - {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.summary:
+        try:
+            joined = "\n".join(text for _, text in conversation)
+            print(summarize_text(joined))
+        except Exception as exc:  # pragma: no cover - placeholder
+            print(f"Error during summarization: {exc}", file=sys.stderr)
+            sys.exit(1)
+        return
+
+    if args.html:
+        print(format_html(conversation))
+    elif args.ascii:
+        format_ascii(conversation)
+    else:
+        print(format_markdown(conversation))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/transcribe-audio.py
+++ b/src/transcribe-audio.py
@@ -21,57 +21,9 @@ The OpenAI API key is read from a .env file or the OPENAI_API_KEY environment va
 import os
 import sys
 import argparse
-from dotenv import load_dotenv
-from openai import OpenAI
 from typing import Optional
 
-
-
-def get_api_key():
-    """Load API key from .env or environment variable"""
-    load_dotenv()
-    return os.getenv("OPENAI_API_KEY")
-
-
-api_key = get_api_key()
-if  api_key is None:
-    print(
-        "Error: OPENAI_API_KEY not set in .env or environment variables",
-        file=sys.stderr
-    )
-    sys.exit(1)
-else:
-    # Initialize OpenAI client with the API key
-
-    client = OpenAI(api_key=api_key)
-
-
-
-def transcribe_audio(input_path: str, language: Optional[str] = None, prompt: Optional[str] = None) -> str:
-    """
-    Transcribe the given audio file using OpenAI's gpt-4o-transcribe model.
-    Returns the transcribed text.
-    """
-    try:
-        with open(input_path, "rb") as audio_file:
-            response =  client.audio.transcriptions.create(model="gpt-4o-transcribe",
-            file=audio_file)
-            
-        with open(input_path, "rb") as audio_file:
-            # Only include language/prompt if provided (kwargs pattern)
-            kwargs = {"model": "gpt-4o-transcribe", "file": audio_file}
-            if language:
-                kwargs["language"] = language
-            if prompt:
-                kwargs["prompt"] = prompt
-            response = client.audio.transcriptions.create(**kwargs)    
-    except Exception as e:
-        print(f"Error during transcription: {e}", file=sys.stderr)
-        sys.exit(1)
-    # Depending on response type, extract text attribute or use string directly
-    if isinstance(response, str):
-        return response
-    return getattr(response, "text", "")  # response.text holds transcript text ([github.com](https://github.com/openai/openai-python/issues/1633?utm_source=chatgpt.com))
+from ai import transcribe_audio
 
 
 
@@ -97,15 +49,9 @@ def main():
 
     args = parser.parse_args()
 
-    api_key = get_api_key()
-    if not api_key:
-        print(
-            "Error: OPENAI_API_KEY not set in .env or environment variables",
-            file=sys.stderr
-        )
-        sys.exit(1)
-
-    transcript = transcribe_audio(args.input, language=args.language, prompt=args.prompt)
+    transcript = transcribe_audio(
+        args.input, language=args.language, prompt=args.prompt
+    )
 
     if args.output:
         try:


### PR DESCRIPTION
## Summary
- modularize AI access in new `ai.py`
- refactor `transcribe-audio` to use the new module
- add new `chat-peek` CLI for inspecting chat logs
- document the new tool and optional dependencies

## Testing
- `python3 -m compileall -q src README.md`
- `python3 -m py_compile src/chat-peek.py src/transcribe-audio.py src/ai.py`
- *(failed: run `python3 src/chat-peek.py chat_export.json` due to missing `dotenv`)*