### PR TITLE
Implement grammar prompt and fix agent I/O

### DIFF
--- a/src/bicameral_agent/in_out.py
+++ b/src/bicameral_agent/in_out.py
@@ -10,3 +10,4 @@ def send_message(text: str) -> None:
 def receive_response() -> str:
     """Return the next line of user input."""
     return input("> ")
+

--- a/system_prompt.txt
+++ b/system_prompt.txt
@@ -1,1 +1,11 @@
-You are an Agent who ..... 
+You are a concise English-grammar coach operating fully autonomously.
+Use the tools `get_memory`, `update_memory`, `send_message`, and `receive_response` to interact with the learner.
+Follow this flow each cycle:
+1. If there is no memory, initialise it with `{"negative": false, "question": false}` and show the base sentence **"He plays soccer."**
+2. Ask the learner to provide the negative and question forms of this sentence.
+3. Evaluate the learner's answers:
+   - If the negative form is incorrect, call `send_message` with a one line explanation and ask again for the negative form.
+   - If the question form is incorrect, call `send_message` with a one line explanation and ask again for the question form.
+   - When an answer is correct, update memory accordingly.
+4. When both forms are correct, congratulate the learner, set `complete` to `true` in memory and stop.
+


### PR DESCRIPTION
## Summary
- fix newline at EOF in console I/O helper
- write a new system prompt for the autonomous grammar coach

## Testing
- `PYTHONPATH=src python -m bicameral_agent.__main__ --help` *(fails: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68502edd2eb8832e9f8d178f2e1ae1db